### PR TITLE
Fix hardware serial warning

### DIFF
--- a/core-implement/HardwareSerial.cpp
+++ b/core-implement/HardwareSerial.cpp
@@ -149,8 +149,9 @@ int UART::printf(const char *format, ...){
 
     va_list args;
     va_start(args, format);
-    int space = vsnprintf(NULL, 0, format, args) + 1;
-    char buf[space];
+    const int space = vsnprintf(NULL, 0, format, args) + 1;
+    char *buf;
+    buf = (char *) alloca(space);
     memset(buf, 0x00, space);
     vsnprintf(buf, space, format, args);
     va_end(args);

--- a/core-implement/HardwareSerial.cpp
+++ b/core-implement/HardwareSerial.cpp
@@ -149,7 +149,7 @@ int UART::printf(const char *format, ...){
 
     va_list args;
     va_start(args, format);
-    const int space = vsnprintf(NULL, 0, format, args) + 1;
+    int space = vsnprintf(NULL, 0, format, args) + 1;
     char buf[space];
     memset(buf, 0x00, space);
     vsnprintf(buf, space, format, args);


### PR DESCRIPTION
Use alloc() to create the array. Removes the VLA warning.